### PR TITLE
Updated to register server.js as a command when "npm install -g" is run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "npm-offline",
   "description": "An npm registry proxy that uses your npm cache to retrieve modules, allowing for offline access to any modules you've previously installed pretty much ever.",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "index.js",
+  "bin": {
+    "npm-offline": "./server.js"
+  },  
   "dependencies": {
     "read-package-json": "^1.1.8",
     "map-async": "^0.1.1",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var npm = require('npmconf')
 var http = require('http')
 var cache = require('./')


### PR DESCRIPTION
`npm install -g npm-offline` doesn't install a command at the moment. So, `npm-offline` doesn't do anything.

I added a bin entry in package.json so that `npm install -g` creates a symlink to server.js so that the `npm-offline` starts the server. It seems to work.

This is a great project, BTW! I've really needed this for the train. I've just been copying and manually updating package.json.
